### PR TITLE
Removed (almost) all Try examples in documentation/comment blocks

### DIFF
--- a/src/test/kotlin/arrow/DataTypeExamples.kt
+++ b/src/test/kotlin/arrow/DataTypeExamples.kt
@@ -10,209 +10,195 @@ import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
 import arrow.core.Tuple3
+import arrow.core.extensions.either.applicative.applicative
 import arrow.core.extensions.either.applicativeError.handleError
+import arrow.core.extensions.either.functor.functor
 import arrow.core.extensions.fx
 import arrow.core.extensions.option.applicative.applicative
 import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.handleErrorWith
-import io.kotlintest.Matcher
-import io.kotlintest.Result
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FreeSpec
-import kotlin.reflect.KClass
 
 /*** Arrow.io documentation as runnable code ***/
-class DataTypeExamples : FreeSpec() { init {
+class DataTypeExamples : FreeSpec() {
 
-    /**
-     * Option http://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-option/
-     ***/
-    "Option: Some or None?" - {
-        val someValue: Option<Int> = Some(42)
-        val noneValue: Option<Int> = None
+    init {
+        /**
+         * Option http://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-option/
+         ***/
+        "Option: Some or None?" - {
+            val someValue: Option<Int> = Some(42)
+            val noneValue: Option<Int> = None
 
-        "getOrElse" {
-            someValue.getOrElse { -1 }.shouldBe<Int, Int>(42)
-            noneValue.getOrElse { -1 }.shouldBe(-1)
-        }
-
-        "is it None?" {
-            (someValue is None) shouldBe false
-            (noneValue is None) shouldBe true
-        }
-
-        "When statement" {
-            // Option can also be used with when statements:
-            val msg = when (someValue) {
-                is Some -> "ok"
-                None -> "ko"
+            "getOrElse" {
+                someValue.getOrElse { -1 }.shouldBe<Int, Int>(42)
+                noneValue.getOrElse { -1 }.shouldBe(-1)
             }
-            msg shouldBe "ok"
-        }
 
-        "Functor/Foldable style operations" {
-            // An alternative for pattern matching is performing Functor/Foldable style operations.
-            // This is possible because an option could be looked at as a collection or foldable structure with either one or zero elements.
-            // One of these operations is map. This operation allows us to map the inner value to a different type while preserving the option
-            someValue.map { msg -> msg / 6 } shouldBe Some(7)
-            noneValue.map { msg -> msg / 6 } shouldBe None
-        }
-
-        "Fold" {
-            // Fold will extract the value from the option, or provide a default if the value is None
-            someValue.fold({ 1 }, { it * 3 }) shouldBe 126
-            noneValue.fold({ 1 }, { it * 3 }) shouldBe 1
-        }
-
-        "Applicative" {
-            // Computing over independent values
-            val tuple = Option.applicative().tupled(Option(1), Option("Hello"), Option(20.0))
-            tuple shouldBe Some(Tuple3(a = 1, b = "Hello", c = 20.0))
-        }
-
-        "Monad" {
-            // Computing over dependent values ignoring absence
-            val six = Option.fx {
-                val (a) = Option(1)
-                val (b) = Option(1 + a)
-                val (c) = Option(1 + b)
-                a + b + c
+            "is it None?" {
+                (someValue is None) shouldBe false
+                (noneValue is None) shouldBe true
             }
-            six shouldBe Some(6)
 
-            val none = Option.fx {
-                val (a) = Option(1)
-                val (b) = noneValue
-                val (c) = Option(1 + b)
-                a + b + c
-            }
-            none shouldBe None
-        }
-    }
-
-    // Either http://arrow.io/docs/apidocs/arrow-core-data/arrow.core/-either/
-    "Either left or right" - {
-        fun parse(s: String): ProblemOrInt = try {
-            Either.right(s.toInt())
-        } catch (e: Throwable) {
-            Either.left(invalidInt)
-        }
-
-        fun reciprocal(i: Int): Either<Problem, Double> = when (i) {
-            0 -> Left(noReciprocal)
-            else -> Either.Right(1.0 / i)
-        }
-
-        fun magic(s: String): Either<Problem, String> =
-            parse(s).flatMap { reciprocal(it) }.map { it.toString() }
-
-        var either: ProblemOrInt
-
-        "Right" {
-            either = Either.right(5)
-            either shouldBe Either.Right(5)
-            either.getOrElse { 0 } shouldBe 5
-            either.map { it + 1 } shouldBe Either.right(6)
-            either.flatMap { Either.right(6) } shouldBe Either.right(6)
-            either.flatMap { Left(somethingWentWRong) } shouldBe Left(somethingWentWRong)
-        }
-
-        "Left" {
-            // either is right-biaised
-            either = Either.Left(somethingWentWRong)
-            either shouldBe Left(somethingWentWRong)
-            either.getOrElse { 0 } shouldBe 0
-            either.map { it + 1 } shouldBe either
-            either.flatMap { Left(somethingExploded) } shouldBe either
-        }
-
-        "Either rather than exception" {
-            parse("Not an number") shouldBe Left(invalidInt)
-            parse("2") shouldBe Either.right(2)
-        }
-
-        "Combinators" {
-            magic("0") shouldBe Left(noReciprocal)
-            magic("Not a number") shouldBe Left(invalidInt)
-            magic("1") shouldBe Either.right("1.0")
-        }
-
-        "Fold" {
-            // When you want to handle both cases of the computation you can use fold.
-            // With fold we provide two functions,
-            // one for transforming a failure into a new value,
-            // the second one to transform the success value into a new one:
-            val gain = Either.catch { playLottery(99) }
-            gain.fold({ 4 }, { error("not expected") }) shouldBe 4
-
-            val jackPot = Either.catch { playLottery(42) }
-            jackPot.fold({ error("not expected") }, { it * 100 }) shouldBe 100_000
-        }
-
-        "Functor" {
-            // Transforming the value, if the computation is a success:
-            val actual = Either.functor<Int>().run {
-                (try {
-                    Either.right("3".toInt())
-                } catch (e: Throwable) {
-                    Either.left(e)
-                }).map { it + 1 }
-            }
-            actual shouldBe Either.Right(4)
-        }
-
-        "Applicative" {
-            // Computing over independent values:
-            val tryHarder = Either.applicative<Throwable>().tupled(Either.Right(5), Either.Right(3), Either.Left(IllegalArgumentException("")))
-            tryHarder shouldBe aFailureOfType(IllegalArgumentException::class)
-        }
-    }
-
-    "Try and recover" - {
-
-        "Old school" {
-
-            val dollars = try {
-                playLottery(9)
-            } catch (e: AuthorizationException) {
-                0
-            }
-            dollars shouldBe 0
-        }
-
-        "Either.catch { .. } " {
-            val gain: Either<Throwable, Int> = Either.catch { playLottery(9) }
-
-            gain shouldBe aFailureOfType(AuthorizationException::class)
-
-            gain.getOrElse { 0 } shouldBe 0
-        }
-
-        "Recover" {
-            val gain = Either.catch { playLottery(99) }
-            gain.handleError { 0 } shouldBe Either.Right(0)
-            gain.handleErrorWith {
-                try {
-                    Either.Right(playLottery(42))
-                } catch (e: Throwable) {
-                    Either.Left(e)
+            "When statement" {
+                // Option can also be used with when statements:
+                val msg = when (someValue) {
+                    is Some -> "ok"
+                    None -> "ko"
                 }
-            } shouldBe Either.Right(1000)
-        }
-    }
-}
+                msg shouldBe "ok"
+            }
 
-    fun aFailureOfType(expected: KClass<*>): Matcher<Either<Throwable, Int>> = object : Matcher<Either<Throwable, Int>> {
-        override fun test(value: Either<Throwable, Int>): Result = when (value) {
-            is Either.Right -> Result(false, "Expected a failure, got $value", "Received expected failure")
-            is Either.Left -> {
-                val javaClass = value.javaClass
-                Result(
-                    expected.java.isAssignableFrom(javaClass),
-                    "Expected Either.Left(${expected.java}), got $value",
-                    "Received expected failure"
-                )
+            "Functor/Foldable style operations" {
+                // An alternative for pattern matching is performing Functor/Foldable style operations.
+                // This is possible because an option could be looked at as a collection or foldable structure with either one or zero elements.
+                // One of these operations is map. This operation allows us to map the inner value to a different type while preserving the option
+                someValue.map { msg -> msg / 6 } shouldBe Some(7)
+                noneValue.map { msg -> msg / 6 } shouldBe None
+            }
+
+            "Fold" {
+                // Fold will extract the value from the option, or provide a default if the value is None
+                someValue.fold({ 1 }, { it * 3 }) shouldBe 126
+                noneValue.fold({ 1 }, { it * 3 }) shouldBe 1
+            }
+
+            "Applicative" {
+                // Computing over independent values
+                val tuple = Option.applicative().tupled(Option(1), Option("Hello"), Option(20.0))
+                tuple shouldBe Some(Tuple3(a = 1, b = "Hello", c = 20.0))
+            }
+
+            "Monad" {
+                // Computing over dependent values ignoring absence
+                val six = Option.fx {
+                    val (a) = Option(1)
+                    val (b) = Option(1 + a)
+                    val (c) = Option(1 + b)
+                    a + b + c
+                }
+                six shouldBe Some(6)
+
+                val none = Option.fx {
+                    val (a) = Option(1)
+                    val (b) = noneValue
+                    val (c) = Option(1 + b)
+                    a + b + c
+                }
+                none shouldBe None
+            }
+        }
+
+        // Either http://arrow.io/docs/apidocs/arrow-core-data/arrow.core/-either/
+        "Either left or right" - {
+            fun parse(s: String): ProblemOrInt = try {
+                Either.right(s.toInt())
+            } catch (e: Throwable) {
+                Either.left(invalidInt)
+            }
+
+            fun reciprocal(i: Int): Either<Problem, Double> = when (i) {
+                0 -> Left(noReciprocal)
+                else -> Either.Right(1.0 / i)
+            }
+
+            fun magic(s: String): Either<Problem, String> =
+                parse(s).flatMap { reciprocal(it) }.map { it.toString() }
+
+            var either: ProblemOrInt
+
+            "Right" {
+                either = Either.right(5)
+                either shouldBe Either.Right(5)
+                either.getOrElse { 0 } shouldBe 5
+                either.map { it + 1 } shouldBe Either.right(6)
+                either.flatMap { Either.right(6) } shouldBe Either.right(6)
+                either.flatMap { Left(somethingWentWRong) } shouldBe Left(somethingWentWRong)
+            }
+
+            "Left" {
+                // either is right-biaised
+                either = Either.Left(somethingWentWRong)
+                either shouldBe Left(somethingWentWRong)
+                either.getOrElse { 0 } shouldBe 0
+                either.map { it + 1 } shouldBe either
+                either.flatMap { Left(somethingExploded) } shouldBe either
+            }
+
+            "Either rather than exception" {
+                parse("Not an number") shouldBe Left(invalidInt)
+                parse("2") shouldBe Either.right(2)
+            }
+
+            "Combinators" {
+                magic("0") shouldBe Left(noReciprocal)
+                magic("Not a number") shouldBe Left(invalidInt)
+                magic("1") shouldBe Either.right("1.0")
+            }
+
+            "Fold" {
+                // When you want to handle both cases of the computation you can use fold.
+                // With fold we provide two functions,
+                // one for transforming a failure into a new value,
+                // the second one to transform the success value into a new one:
+                val gain = Either.catch { playLottery(99) }
+                gain.fold({ 4 }, { error("not expected") }) shouldBe 4
+
+                val jackPot = Either.catch { playLottery(42) }
+                jackPot.fold({ error("not expected") }, { it * 100 }) shouldBe 100_000
+            }
+
+            "Functor" {
+                // Transforming the value, if the computation is a success:
+                val actual = Either.functor<Int>().run {
+                    (try {
+                        Either.right("3".toInt())
+                    } catch (e: Throwable) {
+                        Either.left(e)
+                    }).map { it + 1 }
+                }
+                actual shouldBe Either.Right(4)
+            }
+
+            "Applicative" {
+                // Computing over independent values:
+                val exception = IllegalArgumentException("")
+                val tryHarder = Either.applicative<Throwable>().tupledN(Either.Right(5), Either.Right(3), Either.Left(exception))
+                tryHarder shouldBe Left(exception)
+            }
+        }
+
+        "Try and recover" - {
+
+            "Old school" {
+                val dollars = try {
+                    playLottery(9)
+                } catch (e: AuthorizationException) {
+                    0
+                }
+                dollars shouldBe 0
+            }
+
+            "Either.catch { .. } " {
+                val gain: Either<Throwable, Int> = Either.catch { playLottery(9) }
+
+                gain shouldBe Left(AuthorizationException)
+
+                gain.getOrElse { 0 } shouldBe 0
+            }
+
+            "Recover" {
+                val gain = Either.catch { playLottery(99) }
+                gain.handleError { 0 } shouldBe Either.Right(0)
+                gain.handleErrorWith {
+                    try {
+                        Either.Right(playLottery(42))
+                    } catch (e: Throwable) {
+                        Either.Left(e)
+                    }
+                } shouldBe Either.Right(1000)
             }
         }
     }

--- a/src/test/kotlin/arrow/DataTypeExamples.kt
+++ b/src/test/kotlin/arrow/DataTypeExamples.kt
@@ -74,17 +74,17 @@ class DataTypeExamples : FreeSpec() {
             "Monad" {
                 // Computing over dependent values ignoring absence
                 val six = Option.fx {
-                    val (a) = Option(1)
-                    val (b) = Option(1 + a)
-                    val (c) = Option(1 + b)
+                    val a = !Option(1)
+                    val b = !Option(1 + a)
+                    val c = !Option(1 + b)
                     a + b + c
                 }
                 six shouldBe Some(6)
 
                 val none = Option.fx {
-                    val (a) = Option(1)
-                    val (b) = noneValue
-                    val (c) = Option(1 + b)
+                    val a = !Option(1)
+                    val b = !noneValue
+                    val c = !Option(1 + b)
                     a + b + c
                 }
                 none shouldBe None
@@ -119,7 +119,7 @@ class DataTypeExamples : FreeSpec() {
             }
 
             "Left" {
-                // either is right-biaised
+                // either is right-biased
                 either = Either.Left(somethingWentWRong)
                 either shouldBe Left(somethingWentWRong)
                 either.getOrElse { 0 } shouldBe 0

--- a/src/test/kotlin/arrow/DataTypeExamples.kt
+++ b/src/test/kotlin/arrow/DataTypeExamples.kt
@@ -5,23 +5,16 @@ import arrow.Problem.noReciprocal
 import arrow.Problem.somethingExploded
 import arrow.Problem.somethingWentWRong
 import arrow.core.Either
-import arrow.core.Failure
 import arrow.core.Left
 import arrow.core.None
 import arrow.core.Option
-import arrow.core.Right
 import arrow.core.Some
-import arrow.core.Success
-import arrow.core.Try
-import arrow.core.TryException
 import arrow.core.Tuple3
-import arrow.core.getOrElse
-import arrow.core.extensions.`try`.applicative.applicative
-import arrow.core.extensions.`try`.functor.functor
+import arrow.core.extensions.either.applicativeError.handleError
 import arrow.core.extensions.fx
 import arrow.core.extensions.option.applicative.applicative
 import arrow.core.flatMap
-import arrow.core.handleError
+import arrow.core.getOrElse
 import arrow.core.handleErrorWith
 import io.kotlintest.Matcher
 import io.kotlintest.Result
@@ -32,202 +25,206 @@ import kotlin.reflect.KClass
 /*** Arrow.io documentation as runnable code ***/
 class DataTypeExamples : FreeSpec() { init {
 
-  /**
-   * Option http://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-option/
-   ***/
-  "Option: Some or None?" - {
-    val someValue: Option<Int> = Some(42)
-    val noneValue: Option<Int> = None
+    /**
+     * Option http://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-option/
+     ***/
+    "Option: Some or None?" - {
+        val someValue: Option<Int> = Some(42)
+        val noneValue: Option<Int> = None
 
-    "getOrElse" {
-      someValue.getOrElse { -1 }.shouldBe<Int, Int>(42)
-      noneValue.getOrElse { -1 }.shouldBe(-1)
+        "getOrElse" {
+            someValue.getOrElse { -1 }.shouldBe<Int, Int>(42)
+            noneValue.getOrElse { -1 }.shouldBe(-1)
+        }
+
+        "is it None?" {
+            (someValue is None) shouldBe false
+            (noneValue is None) shouldBe true
+        }
+
+        "When statement" {
+            // Option can also be used with when statements:
+            val msg = when (someValue) {
+                is Some -> "ok"
+                None -> "ko"
+            }
+            msg shouldBe "ok"
+        }
+
+        "Functor/Foldable style operations" {
+            // An alternative for pattern matching is performing Functor/Foldable style operations.
+            // This is possible because an option could be looked at as a collection or foldable structure with either one or zero elements.
+            // One of these operations is map. This operation allows us to map the inner value to a different type while preserving the option
+            someValue.map { msg -> msg / 6 } shouldBe Some(7)
+            noneValue.map { msg -> msg / 6 } shouldBe None
+        }
+
+        "Fold" {
+            // Fold will extract the value from the option, or provide a default if the value is None
+            someValue.fold({ 1 }, { it * 3 }) shouldBe 126
+            noneValue.fold({ 1 }, { it * 3 }) shouldBe 1
+        }
+
+        "Applicative" {
+            // Computing over independent values
+            val tuple = Option.applicative().tupled(Option(1), Option("Hello"), Option(20.0))
+            tuple shouldBe Some(Tuple3(a = 1, b = "Hello", c = 20.0))
+        }
+
+        "Monad" {
+            // Computing over dependent values ignoring absence
+            val six = Option.fx {
+                val (a) = Option(1)
+                val (b) = Option(1 + a)
+                val (c) = Option(1 + b)
+                a + b + c
+            }
+            six shouldBe Some(6)
+
+            val none = Option.fx {
+                val (a) = Option(1)
+                val (b) = noneValue
+                val (c) = Option(1 + b)
+                a + b + c
+            }
+            none shouldBe None
+        }
     }
 
-    "is it None?" {
-      (someValue is None) shouldBe false
-      (noneValue is None) shouldBe true
+    // Either http://arrow.io/docs/apidocs/arrow-core-data/arrow.core/-either/
+    "Either left or right" - {
+        fun parse(s: String): ProblemOrInt = try {
+            Either.right(s.toInt())
+        } catch (e: Throwable) {
+            Either.left(invalidInt)
+        }
+
+        fun reciprocal(i: Int): Either<Problem, Double> = when (i) {
+            0 -> Left(noReciprocal)
+            else -> Either.Right(1.0 / i)
+        }
+
+        fun magic(s: String): Either<Problem, String> =
+            parse(s).flatMap { reciprocal(it) }.map { it.toString() }
+
+        var either: ProblemOrInt
+
+        "Right" {
+            either = Either.right(5)
+            either shouldBe Either.Right(5)
+            either.getOrElse { 0 } shouldBe 5
+            either.map { it + 1 } shouldBe Either.right(6)
+            either.flatMap { Either.right(6) } shouldBe Either.right(6)
+            either.flatMap { Left(somethingWentWRong) } shouldBe Left(somethingWentWRong)
+        }
+
+        "Left" {
+            // either is right-biaised
+            either = Either.Left(somethingWentWRong)
+            either shouldBe Left(somethingWentWRong)
+            either.getOrElse { 0 } shouldBe 0
+            either.map { it + 1 } shouldBe either
+            either.flatMap { Left(somethingExploded) } shouldBe either
+        }
+
+        "Either rather than exception" {
+            parse("Not an number") shouldBe Left(invalidInt)
+            parse("2") shouldBe Either.right(2)
+        }
+
+        "Combinators" {
+            magic("0") shouldBe Left(noReciprocal)
+            magic("Not a number") shouldBe Left(invalidInt)
+            magic("1") shouldBe Either.right("1.0")
+        }
+
+        "Fold" {
+            // When you want to handle both cases of the computation you can use fold.
+            // With fold we provide two functions,
+            // one for transforming a failure into a new value,
+            // the second one to transform the success value into a new one:
+            val gain = Either.catch { playLottery(99) }
+            gain.fold({ 4 }, { error("not expected") }) shouldBe 4
+
+            val jackPot = Either.catch { playLottery(42) }
+            jackPot.fold({ error("not expected") }, { it * 100 }) shouldBe 100_000
+        }
+
+        "Functor" {
+            // Transforming the value, if the computation is a success:
+            val actual = Either.functor<Int>().run {
+                (try {
+                    Either.right("3".toInt())
+                } catch (e: Throwable) {
+                    Either.left(e)
+                }).map { it + 1 }
+            }
+            actual shouldBe Either.Right(4)
+        }
+
+        "Applicative" {
+            // Computing over independent values:
+            val tryHarder = Either.applicative<Throwable>().tupled(Either.Right(5), Either.Right(3), Either.Left(IllegalArgumentException("")))
+            tryHarder shouldBe aFailureOfType(IllegalArgumentException::class)
+        }
     }
 
-    "When statement" {
-      // Option can also be used with when statements:
-      val msg = when (someValue) {
-        is Some -> "ok"
-        None -> "ko"
-      }
-      msg shouldBe "ok"
+    "Try and recover" - {
+
+        "Old school" {
+
+            val dollars = try {
+                playLottery(9)
+            } catch (e: AuthorizationException) {
+                0
+            }
+            dollars shouldBe 0
+        }
+
+        "Either.catch { .. } " {
+            val gain: Either<Throwable, Int> = Either.catch { playLottery(9) }
+
+            gain shouldBe aFailureOfType(AuthorizationException::class)
+
+            gain.getOrElse { 0 } shouldBe 0
+        }
+
+        "Recover" {
+            val gain = Either.catch { playLottery(99) }
+            gain.handleError { 0 } shouldBe Either.Right(0)
+            gain.handleErrorWith {
+                try {
+                    Either.Right(playLottery(42))
+                } catch (e: Throwable) {
+                    Either.Left(e)
+                }
+            } shouldBe Either.Right(1000)
+        }
     }
-
-    "Functor/Foldable style operations" {
-      // An alternative for pattern matching is performing Functor/Foldable style operations.
-      // This is possible because an option could be looked at as a collection or foldable structure with either one or zero elements.
-      // One of these operations is map. This operation allows us to map the inner value to a different type while preserving the option
-      someValue.map { msg -> msg / 6 } shouldBe Some(7)
-      noneValue.map { msg -> msg / 6 } shouldBe None
-    }
-
-    "Fold" {
-      // Fold will extract the value from the option, or provide a default if the value is None
-      someValue.fold({ 1 }, { it * 3 }) shouldBe 126
-      noneValue.fold({ 1 }, { it * 3 }) shouldBe 1
-    }
-
-    "Applicative" {
-      // Computing over independent values
-      val tuple = Option.applicative().tupled(Option(1), Option("Hello"), Option(20.0))
-      tuple shouldBe Some(Tuple3(a = 1, b = "Hello", c = 20.0))
-    }
-
-    "Monad" {
-      // Computing over dependent values ignoring absence
-      val six = Option.fx {
-        val (a) = Option(1)
-        val (b) = Option(1 + a)
-        val (c) = Option(1 + b)
-        a + b + c
-      }
-      six shouldBe Some(6)
-
-      val none = Option.fx {
-        val (a) = Option(1)
-        val (b) = noneValue
-        val (c) = Option(1 + b)
-        a + b + c
-      }
-      none shouldBe None
-    }
-  }
-
-  // http://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-try/
-  "Try and recover" - {
-
-    "Old school" {
-
-      val dollars = try {
-        playLottery(9)
-      } catch (e: AuthorizationException) {
-        0
-      }
-      dollars shouldBe 0
-    }
-
-    "Try { .. } " {
-      val gain: Try<Int> = Try { playLottery(9) }
-
-      gain shouldBe aFailureOfType(AuthorizationException::class)
-
-      gain.getOrElse { 0 } shouldBe 0
-    }
-
-    "filter" {
-      // If you want to perform a check on a possible success,
-      // you can use filter to convert successful computations in failures if conditions aren’t met:
-      val tryJackpot = Try { playLottery(10) }.filter { it > 500 }
-      tryJackpot shouldBe aFailureOfType(TryException.PredicateException::class)
-    }
-
-    "Recover" {
-      val gain = Try { playLottery(99) }
-      gain.handleError { 0 } shouldBe Try.Success(0)
-
-      gain.handleErrorWith { Try { playLottery(42) } } shouldBe Try.Success(1000)
-    }
-
-    "Fold" {
-      // When you want to handle both cases of the computation you can use fold.
-      // With fold we provide two functions,
-      // one for transforming a failure into a new value,
-      // the second one to transform the success value into a new one:
-      val gain = Try { playLottery(99) }
-      gain.fold({ 4 }, { error("not expected") }) shouldBe 4
-
-      val jackPot = Try { playLottery(42) }
-      jackPot.fold({ error("not expected") }, { it * 100 }) shouldBe 100_000
-    }
-
-    "Functor" {
-      // Transforming the value, if the computation is a success:
-      val actual = Try.functor().run { Try { "3".toInt() }.map { it + 1 } }
-      actual shouldBe Try.Success(4)
-    }
-
-    "Applicative" {
-      // Computing over independent values:
-      val tryHarder = Try.applicative().tupled(
-        Try { "3".toInt() },
-        Try { "5".toInt() },
-        Try { "nope".toInt() }
-      )
-      tryHarder shouldBe aFailureOfType(NumberFormatException::class)
-    }
-  }
-
-  // Either http://arrow.io/docs/apidocs/arrow-core-data/arrow.core/-either/
-  "Either left or right" - {
-    fun parse(s: String): ProblemOrInt = Try { Right(s.toInt()) }.getOrElse { Left(invalidInt) }
-    fun reciprocal(i: Int): Either<Problem, Double> = when (i) {
-      0 -> Left(noReciprocal)
-      else -> Either.Right(1.0 / i)
-    }
-
-    fun magic(s: String): Either<Problem, String> =
-      parse(s).flatMap { reciprocal(it) }.map { it.toString() }
-
-    var either: ProblemOrInt
-
-    "Right" {
-      either = Either.right(5)
-      either shouldBe Either.Right(5)
-      either.getOrElse { 0 } shouldBe 5
-      either.map { it + 1 } shouldBe Either.right(6)
-      either.flatMap { Either.right(6) } shouldBe Either.right(6)
-      either.flatMap { Left(somethingWentWRong) } shouldBe Left(somethingWentWRong)
-    }
-
-    "Left" {
-      // either is right-biaised
-      either = Either.Left(somethingWentWRong)
-      either shouldBe Left(somethingWentWRong)
-      either.getOrElse { 0 } shouldBe 0
-      either.map { it + 1 } shouldBe either
-      either.flatMap { Left(somethingExploded) } shouldBe either
-    }
-
-    "Either rather than exception" {
-      parse("Not an number") shouldBe Left(invalidInt)
-      parse("2") shouldBe Either.right(2)
-    }
-
-    "Combinators" {
-      magic("0") shouldBe Left(noReciprocal)
-      magic("Not a number") shouldBe Left(invalidInt)
-      magic("1") shouldBe Either.right("1.0")
-    }
-  }
 }
 
-  fun aFailureOfType(expected: KClass<*>): Matcher<Try<Int>> = object : Matcher<Try<Int>> {
-    override fun test(value: Try<Int>): Result = when (value) {
-      is Success -> Result(false, "Expected a failure, got $value", "Received expected failure")
-      is Failure -> {
-        val javaClass = value.exception.javaClass
-        Result(
-          expected.java.isAssignableFrom(javaClass),
-          "Expected Try.Failure(${expected.java}), got $value",
-          "Received expected failure"
-        )
-      }
+    fun aFailureOfType(expected: KClass<*>): Matcher<Either<Throwable, Int>> = object : Matcher<Either<Throwable, Int>> {
+        override fun test(value: Either<Throwable, Int>): Result = when (value) {
+            is Either.Right -> Result(false, "Expected a failure, got $value", "Received expected failure")
+            is Either.Left -> {
+                val javaClass = value.javaClass
+                Result(
+                    expected.java.isAssignableFrom(javaClass),
+                    "Expected Either.Left(${expected.java}), got $value",
+                    "Received expected failure"
+                )
+            }
+        }
     }
-  }
 }
 
 private typealias ProblemOrInt = Either<Problem, Int>
 
 private enum class Problem(val message: String) {
-  somethingWentWRong("Something went wrong"),
-  somethingExploded("Something somethingExploded"),
-  invalidInt("This is not an integer"),
-  noReciprocal("Cannot take noReciprocal of 0.")
+    somethingWentWRong("Something went wrong"),
+    somethingExploded("Something somethingExploded"),
+    invalidInt("This is not an integer"),
+    noReciprocal("Cannot take noReciprocal of 0.")
 }
 
 private open class GeneralException : Exception()
@@ -237,10 +234,10 @@ private object NoConnectionException : GeneralException()
 private object AuthorizationException : GeneralException()
 
 fun playLottery(guess: Int): Int {
-  return when (guess) {
-    42 -> 1000 // jackpot
-    in 10..41 -> 1
-    in 0..9 -> throw AuthorizationException
-    else -> throw NoConnectionException
-  }
+    return when (guess) {
+        42 -> 1000 // jackpot
+        in 10..41 -> 1
+        in 0..9 -> throw AuthorizationException
+        else -> throw NoConnectionException
+    }
 }

--- a/src/test/kotlin/arrow/FpToTheMax.kt
+++ b/src/test/kotlin/arrow/FpToTheMax.kt
@@ -1,21 +1,20 @@
 package arrow
 
+import arrow.core.None
 import arrow.core.Option
-import arrow.core.Try
 import arrow.core.Tuple2
 import arrow.core.toT
-import arrow.mtl.State
-import arrow.mtl.StatePartialOf
-import arrow.mtl.StateApi
 import arrow.fx.IO
 import arrow.fx.extensions.io.monadDefer.monadDefer
 import arrow.fx.fix
 import arrow.fx.typeclasses.MonadDefer
-import arrow.mtl.extensions.monad
+import arrow.mtl.State
+import arrow.mtl.StateApi
+import arrow.mtl.StatePartialOf
 import arrow.mtl.fix
 import arrow.mtl.run
 import arrow.typeclasses.Monad
-import java.util.Random
+import java.util.*
 
 /**
  * This sample is a simple translation in Kotlin (using arrow, of course) of this talk: https://youtu.be/sxudIMiOo68
@@ -23,29 +22,29 @@ import java.util.Random
 object ORandom : Random()
 
 interface Console<F> {
-  fun putStrLn(s: String): Kind<F, Unit>
-  fun getStrLn(): Kind<F, String>
+    fun putStrLn(s: String): Kind<F, Unit>
+    fun getStrLn(): Kind<F, String>
 }
 
 class ConsoleImpl<F>(val delay: MonadDefer<F>) : Console<F> {
-  override fun putStrLn(s: String): Kind<F, Unit> = delay.later { println(s) }
-  override fun getStrLn(): Kind<F, String> = delay.later { readLine().orEmpty() }
+    override fun putStrLn(s: String): Kind<F, Unit> = delay.later { println(s) }
+    override fun getStrLn(): Kind<F, String> = delay.later { readLine().orEmpty() }
 }
 
 interface FRandom<F> {
-  fun nextInt(upper: Int): Kind<F, Int>
+    fun nextInt(upper: Int): Kind<F, Int>
 }
 
 class FRandomImpl<F>(val delay: MonadDefer<F>) : FRandom<F> {
-  override fun nextInt(upper: Int): Kind<F, Int> = delay.later { ORandom.nextInt(upper) }
+    override fun nextInt(upper: Int): Kind<F, Int> = delay.later { ORandom.nextInt(upper) }
 }
 
 class MonadAndConsoleRandom<F>(M: Monad<F>, C: Console<F>, R: FRandom<F>) : Monad<F> by M, Console<F> by C, FRandom<F> by R
 
 data class TestData(val input: List<String>, val output: List<String>, val nums: List<Int>) {
-  fun putStrLn(s: String): Tuple2<TestData, Unit> = copy(output = output.plus(s)) toT Unit
-  fun getStrLn(): Tuple2<TestData, String> = copy(input = input.drop(1)) toT input[0]
-  fun nextInt(@Suppress("UNUSED_PARAMETER") upper: Int): Tuple2<TestData, Int> = copy(nums = nums.drop(1)) toT nums[0]
+    fun putStrLn(s: String): Tuple2<TestData, Unit> = copy(output = output.plus(s)) toT Unit
+    fun getStrLn(): Tuple2<TestData, String> = copy(input = input.drop(1)) toT input[0]
+    fun nextInt(@Suppress("UNUSED_PARAMETER") upper: Int): Tuple2<TestData, Int> = copy(nums = nums.drop(1)) toT nums[0]
 }
 
 typealias ForTestIO = StatePartialOf<TestData>
@@ -54,61 +53,65 @@ typealias ForTestIO = StatePartialOf<TestData>
 fun <A> TestIO(f: (TestData) -> Tuple2<TestData, A>) = State(f)
 
 class TestIORandom : FRandom<ForTestIO> {
-  override fun nextInt(upper: Int): Kind<ForTestIO, Int> = TestIO { it.nextInt(upper) }
+    override fun nextInt(upper: Int): Kind<ForTestIO, Int> = TestIO { it.nextInt(upper) }
 }
 
 class TestIOConsole : Console<ForTestIO> {
-  override fun putStrLn(s: String): Kind<ForTestIO, Unit> = TestIO { it.putStrLn(s) }
-  override fun getStrLn(): Kind<ForTestIO, String> = TestIO { it.getStrLn() }
+    override fun putStrLn(s: String): Kind<ForTestIO, Unit> = TestIO { it.putStrLn(s) }
+    override fun getStrLn(): Kind<ForTestIO, String> = TestIO { it.getStrLn() }
 }
 
 object FpToTheMax {
 
-  fun parseInt(s: String): Option<Int> = Try { s.toInt() }.toOption()
-
-  fun <F> MonadAndConsoleRandom<F>.checkContinue(name: String): Kind<F, Boolean> = fx.monad {
-    val (_) = putStrLn("Do you want to continue, $name?")
-    val (input) = getStrLn().map { it.toLowerCase() }
-    when (input) {
-      "y" -> just(true)
-      "n" -> just(false)
-      else -> checkContinue(name)
-    }.bind()
-  }
-
-  fun <F> MonadAndConsoleRandom<F>.gameLoop(name: String): Kind<F, Unit> = fx.monad {
-    val (num) = nextInt(5).map { it + 1 }
-    putStrLn("Dear $name, please guess a number from 1 to 5:").bind()
-    val (input) = getStrLn()
-    parseInt(input).fold({ putStrLn("You did not enter a number") }) { guess ->
-      if (guess == num) putStrLn("You guessed right, $name!")
-      else putStrLn("You guessed wrong, $name! The number was: $num")
-    }.bind()
-    val (cont) = checkContinue(name)
-    (if (cont) gameLoop(name) else just(Unit)).bind()
-  }
-
-  fun <F> MonadAndConsoleRandom<F>.fMain(): Kind<F, Unit> = fx.monad {
-    putStrLn("What is your name?").bind()
-    val (name) = getStrLn()
-    putStrLn("Hello $name, welcome to the game").bind()
-    gameLoop(name).bind()
-  }
-
-  @JvmStatic
-  fun main(args: Array<String>) {
-    val module = IO.monadDefer().run {
-      MonadAndConsoleRandom(this, ConsoleImpl(this), FRandomImpl(this))
+    fun parseInt(s: String): Option<Int> = try {
+        Option.just(s.toInt())
+    } catch (e: Throwable) {
+        None
     }
-    val r = module.fMain()
-    r.fix().unsafeRunSync()
-  }
 
-  fun test(): List<String> = run {
-    val testData = TestData(listOf("Plop", "4", "n"), listOf(), listOf(3))
+    fun <F> MonadAndConsoleRandom<F>.checkContinue(name: String): Kind<F, Boolean> = fx.monad {
+        val (_) = putStrLn("Do you want to continue, $name?")
+        val (input) = getStrLn().map { it.toLowerCase() }
+        when (input) {
+            "y" -> just(true)
+            "n" -> just(false)
+            else -> checkContinue(name)
+        }.bind()
+    }
 
-    val module: MonadAndConsoleRandom<ForTestIO> = MonadAndConsoleRandom(StateApi.monad(), TestIOConsole(), TestIORandom())
+    fun <F> MonadAndConsoleRandom<F>.gameLoop(name: String): Kind<F, Unit> = fx.monad {
+        val (num) = nextInt(5).map { it + 1 }
+        putStrLn("Dear $name, please guess a number from 1 to 5:").bind()
+        val (input) = getStrLn()
+        parseInt(input).fold({ putStrLn("You did not enter a number") }) { guess ->
+            if (guess == num) putStrLn("You guessed right, $name!")
+            else putStrLn("You guessed wrong, $name! The number was: $num")
+        }.bind()
+        val (cont) = checkContinue(name)
+        (if (cont) gameLoop(name) else just(Unit)).bind()
+    }
 
-    module.fMain().fix().run(testData).a.output
-  }
+    fun <F> MonadAndConsoleRandom<F>.fMain(): Kind<F, Unit> = fx.monad {
+        putStrLn("What is your name?").bind()
+        val (name) = getStrLn()
+        putStrLn("Hello $name, welcome to the game").bind()
+        gameLoop(name).bind()
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val module = IO.monadDefer().run {
+            MonadAndConsoleRandom(this, ConsoleImpl(this), FRandomImpl(this))
+        }
+        val r = module.fMain()
+        r.fix().unsafeRunSync()
+    }
+
+    fun test(): List<String> = run {
+        val testData = TestData(listOf("Plop", "4", "n"), listOf(), listOf(3))
+
+        val module: MonadAndConsoleRandom<ForTestIO> = MonadAndConsoleRandom(StateApi.monad(), TestIOConsole(), TestIORandom())
+
+        module.fMain().fix().run(testData).a.output
+    }
 }

--- a/src/test/kotlin/arrow/FpToTheMax.kt
+++ b/src/test/kotlin/arrow/FpToTheMax.kt
@@ -70,8 +70,8 @@ object FpToTheMax {
     }
 
     fun <F> MonadAndConsoleRandom<F>.checkContinue(name: String): Kind<F, Boolean> = fx.monad {
-        val (_) = putStrLn("Do you want to continue, $name?")
-        val (input) = getStrLn().map { it.toLowerCase() }
+        putStrLn("Do you want to continue, $name? [y/n]")
+        val input = !getStrLn().map { it.toLowerCase() }
         when (input) {
             "y" -> just(true)
             "n" -> just(false)
@@ -80,22 +80,22 @@ object FpToTheMax {
     }
 
     fun <F> MonadAndConsoleRandom<F>.gameLoop(name: String): Kind<F, Unit> = fx.monad {
-        val (num) = nextInt(5).map { it + 1 }
+        val num = !nextInt(5).map { it + 1 }
         putStrLn("Dear $name, please guess a number from 1 to 5:").bind()
-        val (input) = getStrLn()
+        val input = !getStrLn()
         parseInt(input).fold({ putStrLn("You did not enter a number") }) { guess ->
             if (guess == num) putStrLn("You guessed right, $name!")
             else putStrLn("You guessed wrong, $name! The number was: $num")
         }.bind()
-        val (cont) = checkContinue(name)
+        val cont = !checkContinue(name)
         (if (cont) gameLoop(name) else just(Unit)).bind()
     }
 
     fun <F> MonadAndConsoleRandom<F>.fMain(): Kind<F, Unit> = fx.monad {
-        putStrLn("What is your name?").bind()
-        val (name) = getStrLn()
-        putStrLn("Hello $name, welcome to the game").bind()
-        gameLoop(name).bind()
+        !putStrLn("What is your name?")
+        val name = !getStrLn()
+        !putStrLn("Hello $name, welcome to the game")
+        !gameLoop(name)
     }
 
     @JvmStatic

--- a/src/test/kotlin/arrow/typeclasses/StartHere.kt
+++ b/src/test/kotlin/arrow/typeclasses/StartHere.kt
@@ -1,7 +1,7 @@
 package arrow.typeclasses
 
-import arrow.core.Try
-import arrow.core.handleErrorWith
+import arrow.fx.IO
+import arrow.fx.handleErrorWith
 
 // This code is explained in "Simple dependency management in Kotlin"
 // Video: https://skillsmatter.com/skillscasts/12907-simple-dependency-management-in-kotlin
@@ -14,18 +14,18 @@ typealias Index = Int
 
 data class User(val id: Index)
 
-fun fetchUser(i: Index, network: NetworkModule, dao: DaoDatabase): Try<User> =
-  Try { dao.query("SELECT * FROM Users where id = $i").toUserFromDatabase() }
-    .handleErrorWith {
-      Try { network.fetch(i, mapOf()).toUserFromNetwork() }
-    }
+fun fetchUser(i: Index, network: NetworkModule, dao: DaoDatabase): IO<User> =
+    IO { dao.query("SELECT * FROM Users where id = $i").toUserFromDatabase() }
+        .handleErrorWith {
+            IO { network.fetch(i, mapOf()).toUserFromNetwork() }
+        }
 
 inline fun <A> realWorld(f: () -> A): A = Math.random().let {
-  if (it > 0.0003) {
-    return f()
-  } else {
-    throw RuntimeException("😱 -> $it!")
-  }
+    if (it > 0.0003) {
+        return f()
+    } else {
+        throw RuntimeException("😱 -> $it!")
+    }
 }
 
 // And here's where we'd like to go

--- a/src/test/kotlin/arrow/typeclasses/solved/BusinessLogic.kt
+++ b/src/test/kotlin/arrow/typeclasses/solved/BusinessLogic.kt
@@ -1,20 +1,22 @@
-package com.pacoworks.typeclasses.basics.solved
+package arrow.typeclasses.solved
 
 import arrow.Kind
-import arrow.core.Try
-import arrow.core.handleErrorWith
+import arrow.fx.IO
+import arrow.fx.handleErrorWith
 import arrow.fx.typeclasses.Async
 import arrow.fx.typeclasses.MonadDefer
 import arrow.typeclasses.Index
 import arrow.typeclasses.User
+import com.pacoworks.typeclasses.basics.solved.DomainMapper
+import com.pacoworks.typeclasses.basics.solved.DomainMapperSync
 import kotlin.coroutines.CoroutineContext
 
 // Step 0 - Compose operations
 
 interface RequestOperations : DaoOperations, NetworkOperations, DomainMapper {
-  fun Index.fetchUser(): Try<User> =
-    queryUser().toUserFromDatabase()
-      .handleErrorWith { requestUser().toUserFromNetwork() }
+    fun Index.fetchUser(): IO<User> =
+        queryUser().toUserFromDatabase()
+            .handleErrorWith { requestUser().toUserFromNetwork() }
 }
 
 // So far so good. Let's get rid of Try! Back to the Framework
@@ -22,18 +24,18 @@ interface RequestOperations : DaoOperations, NetworkOperations, DomainMapper {
 // Step 1 - Now with generic containers
 
 interface RequestOperationsSync<F> : DaoOperationsSync<F>, NetworkOperationsSync<F>, DomainMapperSync<F> {
-  fun Index.fetchUser(): Kind<F, User> =
-    queryUser().toUserFromDatabase()
-      .handleErrorWith { requestUser().toUserFromNetwork() }
+    fun Index.fetchUser(): Kind<F, User> =
+        queryUser().toUserFromDatabase()
+            .handleErrorWith { requestUser().toUserFromNetwork() }
 }
 
 // We don't want to execute them right now, silly!
 
 interface RequestOperationsLazy<F> : DaoOperationsSync<F>, NetworkOperationsSync<F>, DomainMapperSync<F>, MonadDefer<F> {
-  fun Index.fetchUser(): Kind<F, User> = defer {
-    queryUser().toUserFromDatabase()
-      .handleErrorWith { requestUser().toUserFromNetwork() }
-  }
+    fun Index.fetchUser(): Kind<F, User> = defer {
+        queryUser().toUserFromDatabase()
+            .handleErrorWith { requestUser().toUserFromNetwork() }
+    }
 }
 
 // That makes the whole operation lazy, but the Framework is still oblivious to threading
@@ -41,12 +43,12 @@ interface RequestOperationsLazy<F> : DaoOperationsSync<F>, NetworkOperationsSync
 // Step 2 - Compose the asynchronous elements
 
 interface RequestOperationsAsync<F> : DaoOperationsAsync<F>, NetworkOperationsAsync<F>, DomainMapperSync<F>, Async<F> {
-  val ctx: CoroutineContext
+    val ctx: CoroutineContext
 
-  fun Index.fetchUser(): Kind<F, User> = defer(ctx) {
-    queryUser().toUserFromDatabase()
-      .handleErrorWith { requestUser().toUserFromNetwork() }
-  }
+    fun Index.fetchUser(): Kind<F, User> = defer(ctx) {
+        queryUser().toUserFromDatabase()
+            .handleErrorWith { requestUser().toUserFromNetwork() }
+    }
 }
 
 // Okay, now what is that mysterious F value and how do you Use it?

--- a/src/test/kotlin/arrow/typeclasses/solved/Framework.kt
+++ b/src/test/kotlin/arrow/typeclasses/solved/Framework.kt
@@ -1,11 +1,12 @@
 @file:Suppress("unused")
 
-package com.pacoworks.typeclasses.basics.solved
+package arrow.typeclasses.solved
 
 import arrow.Kind
 import arrow.core.Try
 import arrow.core.left
 import arrow.core.right
+import arrow.fx.IO
 import arrow.fx.typeclasses.Async
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
@@ -20,18 +21,18 @@ import arrow.typeclasses.UserDto
 interface NetworkOperations {
   val network: NetworkModule
 
-  fun Index.requestUser(): Try<UserDto> =
-    Try { network.fetch(this, mapOf("1" to "2")) }
+  fun Index.requestUser(): IO<UserDto> =
+      IO.effect { network.fetch(this, mapOf("1" to "2")) }
 }
 
 interface DaoOperations {
   val dao: DaoDatabase
 
-  fun Index.queryUser(): Try<UserDao> =
-    Try { dao.query("SELECT * from Users where userId = $this") }
+  fun Index.queryUser(): IO<UserDao> =
+      IO.effect { dao.query("SELECT * from Users where userId = $this") }
 
-  fun Index.queryCompany(): Try<UserDao> =
-    Try { dao.query("SELECT * from Companies where companyId = $this") }
+  fun Index.queryCompany(): IO<UserDao> =
+      IO.effect { dao.query("SELECT * from Companies where companyId = $this") }
 }
 
 // We should probably abstract the Mapper too

--- a/src/test/kotlin/arrow/typeclasses/solved/Mapper.kt
+++ b/src/test/kotlin/arrow/typeclasses/solved/Mapper.kt
@@ -2,6 +2,7 @@ package com.pacoworks.typeclasses.basics.solved
 
 import arrow.Kind
 import arrow.core.Try
+import arrow.fx.IO
 import arrow.typeclasses.MonadError
 import arrow.typeclasses.User
 import arrow.typeclasses.UserDao
@@ -11,11 +12,11 @@ import arrow.typeclasses.realWorld
 // Step 0
 
 interface DomainMapper {
-  fun Try<UserDto>.toUserFromNetwork(): Try<User> =
-    flatMap { user -> Try { realWorld { User(user.id) } } }
+  fun IO<UserDto>.toUserFromNetwork(): IO<User> =
+    flatMap { user -> IO.effect { realWorld { User(user.id) } } }
 
-  fun Try<UserDao>.toUserFromDatabase(): Try<User> =
-    flatMap { user -> Try { realWorld { User(user.id) } } }
+  fun IO<UserDao>.toUserFromDatabase(): IO<User> =
+    flatMap { user -> IO.effect { realWorld { User(user.id) } } }
 }
 
 // See how the Business Logic has to be updated!

--- a/src/test/kotlin/arrow/typeclasses/solved/Usage.kt
+++ b/src/test/kotlin/arrow/typeclasses/solved/Usage.kt
@@ -12,6 +12,7 @@ import arrow.typeclasses.DaoDatabase
 import arrow.typeclasses.Index
 import arrow.typeclasses.NetworkModule
 import arrow.typeclasses.User
+import arrow.typeclasses.solved.RequestOperationsAsync
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext


### PR DESCRIPTION
Original PR can be seen [here](https://github.com/arrow-kt/arrow-core/issues/26).

What version are you currently using? 0.10

What would you like to see?
The documentation includes Try examples. Since Try is deprecated, these examples should be removed (or transitioned to Either examples) to prevent confusion.